### PR TITLE
Feature/#43 delete

### DIFF
--- a/web-service/src/main/java/com/ticketcheater/webservice/controller/GameController.java
+++ b/web-service/src/main/java/com/ticketcheater/webservice/controller/GameController.java
@@ -8,6 +8,7 @@ import com.ticketcheater.webservice.controller.response.game.GameCreateResponse;
 import com.ticketcheater.webservice.controller.response.game.GameReadByHomeResponse;
 import com.ticketcheater.webservice.controller.response.game.GameUpdateResponse;
 import com.ticketcheater.webservice.service.GameService;
+import com.ticketcheater.webservice.service.TicketService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 public class GameController {
 
     private final GameService gameService;
+    private final TicketService ticketService;
 
     @RequireAdmin
     @PostMapping("/create")
@@ -45,6 +47,7 @@ public class GameController {
     @RequireAdmin
     @PatchMapping("/delete/{gameId}")
     public Response<Void> deleteGame(@PathVariable Long gameId) {
+        ticketService.deleteTicket(gameId);
         gameService.deleteGame(gameId);
         return Response.success();
     }
@@ -52,6 +55,7 @@ public class GameController {
     @RequireAdmin
     @PatchMapping("/restore/{gameId}")
     public Response<Void> restoreGame(@PathVariable Long gameId) {
+        ticketService.restoreTicket(gameId);
         gameService.restoreGame(gameId);
         return Response.success();
     }

--- a/web-service/src/test/java/com/ticketcheater/webservice/controller/GameControllerTest.java
+++ b/web-service/src/test/java/com/ticketcheater/webservice/controller/GameControllerTest.java
@@ -9,6 +9,7 @@ import com.ticketcheater.webservice.exception.WebApplicationException;
 import com.ticketcheater.webservice.jwt.JwtTokenProvider;
 import com.ticketcheater.webservice.service.GameService;
 import com.ticketcheater.webservice.service.MemberService;
+import com.ticketcheater.webservice.service.TicketService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,6 +45,9 @@ class GameControllerTest {
 
     @MockBean
     GameService gameService;
+
+    @MockBean
+    TicketService ticketService;
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -269,6 +273,7 @@ class GameControllerTest {
         when(jwtTokenProvider.getName(anyString())).thenReturn(name);
         doNothing().when(memberService).isAdmin(name);
         doNothing().when(gameService).deleteGame(eq(1L));
+        doNothing().when(ticketService).deleteTicket(eq(1L));
 
         mvc.perform(patch("/v1/web/games/delete/1")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
@@ -285,6 +290,7 @@ class GameControllerTest {
         when(jwtTokenProvider.getName(anyString())).thenReturn(name);
         doNothing().when(memberService).isAdmin(name);
         doThrow(new WebApplicationException(ErrorCode.GAME_NOT_FOUND)).when(gameService).deleteGame(eq(1L));
+        doThrow(new WebApplicationException(ErrorCode.GAME_NOT_FOUND)).when(ticketService).deleteTicket(eq(1L));
 
         mvc.perform(patch("/v1/web/games/delete/1")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
@@ -292,7 +298,7 @@ class GameControllerTest {
                 .andExpect(status().is(ErrorCode.GAME_NOT_FOUND.getStatus().value()));
     }
 
-    @DisplayName("관리자가 아닌 회원이 게임 수정 시 오류 발생")
+    @DisplayName("관리자가 아닌 회원이 게임 삭제 시 오류 발생")
     @Test
     void givenNonAdminMember_whenDelete_thenThrowsError() throws Exception {
         String token = "dummy";
@@ -301,6 +307,7 @@ class GameControllerTest {
         when(jwtTokenProvider.getName(anyString())).thenReturn(name);
         doThrow(new WebApplicationException(ErrorCode.INVALID_TOKEN)).when(memberService).isAdmin(name);
         doNothing().when(gameService).deleteGame(eq(1L));
+        doNothing().when(ticketService).deleteTicket(eq(1L));
 
         mvc.perform(patch("/v1/web/games/delete/1")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
@@ -317,6 +324,7 @@ class GameControllerTest {
         when(jwtTokenProvider.getName(anyString())).thenReturn(name);
         doNothing().when(memberService).isAdmin(name);
         doNothing().when(gameService).restoreGame(eq(1L));
+        doNothing().when(ticketService).restoreTicket(eq(1L));
 
         mvc.perform(patch("/v1/web/games/restore/1")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
@@ -333,6 +341,7 @@ class GameControllerTest {
         when(jwtTokenProvider.getName(anyString())).thenReturn(name);
         doNothing().when(memberService).isAdmin(name);
         doThrow(new WebApplicationException(ErrorCode.GAME_ALREADY_EXISTS)).when(gameService).restoreGame(eq(1L));
+        doThrow(new WebApplicationException(ErrorCode.GAME_ALREADY_EXISTS)).when(ticketService).restoreTicket(eq(1L));
 
         mvc.perform(patch("/v1/web/games/restore/1")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
@@ -349,6 +358,7 @@ class GameControllerTest {
         when(jwtTokenProvider.getName(anyString())).thenReturn(name);
         doThrow(new WebApplicationException(ErrorCode.INVALID_TOKEN)).when(memberService).isAdmin(name);
         doNothing().when(gameService).restoreGame(eq(1L));
+        doNothing().when(ticketService).restoreTicket(eq(1L));
 
         mvc.perform(patch("/v1/web/games/restore/1")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))


### PR DESCRIPTION
티켓 삭제, 복구에 대한 기능을 구현했다.

이번에도 마찬가지로 jdbcTemplate 을 이용했다.

티켓 생성과 비슷한 시간대로 요청이 처리된다. 

(티켓 20만 개 생성 44초, 삭제 40초, 복구 38초)

이제, 중요한 기능들은 모두 구현했다.

대기열 구현으로 넘어간다. 그 전에 문서도 작성하도록 한다.

This closes #43 