### PR TITLE
#53 - 순위 조회되지 않는 버그 수정

### DIFF
--- a/flow-service/src/main/java/com/ticketcheater/flowservice/controller/QueueController.java
+++ b/flow-service/src/main/java/com/ticketcheater/flowservice/controller/QueueController.java
@@ -41,7 +41,7 @@ public class QueueController {
         String name = tokenParser.getName(header);
         return queueService.processMember(gameId, name)
                 .flatMap(token -> {
-                    if (token != null) {
+                    if (!token.isEmpty()) {
                         exchange.getResponse().addCookie(
                                 ResponseCookie.from("member-queue-%s-token".formatted(gameId), token)
                                         .maxAge(Duration.ofSeconds(300))

--- a/flow-service/src/main/java/com/ticketcheater/flowservice/service/QueueService.java
+++ b/flow-service/src/main/java/com/ticketcheater/flowservice/service/QueueService.java
@@ -60,7 +60,7 @@ public class QueueService {
                     if(count == 1) {
                         return Mono.just(TokenGenerator.generateToken(gameId, name));
                     } else {
-                        return Mono.empty();
+                        return Mono.just("");
                     }
                 });
     }

--- a/flow-service/src/test/java/com/ticketcheater/flowservice/controller/QueueControllerTest.java
+++ b/flow-service/src/test/java/com/ticketcheater/flowservice/controller/QueueControllerTest.java
@@ -1,5 +1,7 @@
 package com.ticketcheater.flowservice.controller;
 
+import com.ticketcheater.flowservice.controller.response.RankResponse;
+import com.ticketcheater.flowservice.controller.response.TokenResponse;
 import com.ticketcheater.flowservice.exception.ErrorCode;
 import com.ticketcheater.flowservice.exception.FlowApplicationException;
 import com.ticketcheater.flowservice.service.QueueService;
@@ -14,6 +16,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Mono;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -76,7 +79,12 @@ class QueueControllerTest {
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
-                .expectStatus().isOk();
+                .expectStatus().isOk()
+                .expectBody(TokenResponse.class)
+                .consumeWith(response -> {
+                    TokenResponse tokenResponse = response.getResponseBody();
+                    assertThat(tokenResponse).isNotNull();
+                });
     }
 
     @DisplayName("대기열 정보 조회 - 랭킹 조회")
@@ -88,14 +96,19 @@ class QueueControllerTest {
         long rank = 1L;
 
         when(tokenParser.getName(anyString())).thenReturn(name);
-        when(queueService.processMember(anyString(), anyString())).thenReturn(Mono.empty());
+        when(queueService.processMember(anyString(), anyString())).thenReturn(Mono.just(""));
         when(queueService.getRank(anyString(), anyString())).thenReturn(Mono.just(rank));
 
         webTestClient.get().uri("/v1/flow/" + gameId)
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
-                .expectStatus().isOk();
+                .expectStatus().isOk()
+                .expectBody(RankResponse.class)
+                .consumeWith(response -> {
+                    RankResponse rankResponse = response.getResponseBody();
+                    assertThat(rankResponse).isNotNull();
+                });
     }
 
 }

--- a/http/flow.http
+++ b/http/flow.http
@@ -32,6 +32,5 @@ GET http://localhost:8001/flow/1
 Authorization: Bearer {{accessToken}}
 
 > {%
-    let setCookie = response.headers['Set-Cookie'];
-    client.global.set('cookie', setCookie);
+    client.global.set('cookie', response.headers.valueOf('Set-Cookie'));
 %}


### PR DESCRIPTION
진행 큐에 있으면 토큰을 주고 아니면 대기 큐의 순위를 주기로 했다.

그런데, QueueService 클래스의 processMember 메서드에서 빈 문자열이 아니라 Mono.empty() 를 반환하고 있었다. 

이를 빈 문자열로 수정해서 버그를 막았다.

This closes #53 